### PR TITLE
Automated versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,14 +10,13 @@ references:
         sudo dpkg -i goreleaser.deb
 
 jobs:
-  build:
+  test:
     working_directory: /go/src/github.com/fairwindsops/rbac-lookup
 
     docker:
       - image: circleci/golang:1.11
         environment:
           GO111MODULE: "on"
-
     steps:
       - checkout
       - run: go mod download && go mod verify
@@ -26,12 +25,10 @@ jobs:
 
   release:
     working_directory: /go/src/github.com/fairwindsops/rbac-lookup
-
     docker:
       - image: circleci/golang:1.11
         environment:
           GO111MODULE: "on"
-
     steps:
       - checkout
       - run: go mod download && go mod verify
@@ -40,15 +37,15 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  test-and-release:
     jobs:
-      - build:
+      - test:
           filters:
             branches:
               only: /.*/
-  release:
-    jobs:
       - release:
+          requires:
+            - test
           filters:
             branches:
               ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ clean:
 	$(GOCLEAN)
 	$(GOCMD) fmt ./...
 	rm -f $(BINARY_NAME)
-	packr2 clean
 # Cross compilation
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -ldflags "-X main.VERSION=$(VERSION)" -v

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,4 +6,3 @@ Below is a list of work we plan to get done this quarter. Some more details can 
 
 * Add contributing instructions
 * Add release instructions
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,10 +23,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var outputFormat string
-var enableGke bool
-var kubeContext string
-var subjectKind string
+var (
+	version      string
+	commit       string
+	outputFormat string
+	enableGke    bool
+	kubeContext  string
+	subjectKind  string
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "rbac-lookup [subject query]",
@@ -52,7 +56,9 @@ func init() {
 }
 
 // Execute is the primary entrypoint for this CLI
-func Execute() {
+func Execute(VERSION string, COMMIT string) {
+	version = VERSION
+	commit = COMMIT
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,6 +28,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of rbac-lookup",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("rbac-lookup version 0.4.0")
+		fmt.Println("Version:" + version + " Commit:" + commit)
 	},
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,13 @@ import (
 	"github.com/fairwindsops/rbac-lookup/cmd"
 )
 
+var (
+	// version is set during build
+	version = ""
+	// COMMIT is set during build
+	commit = "n/a"
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version, commit)
 }


### PR DESCRIPTION
This will automatically version the releases when we tag them so that we don't have to version bump when releasing. 

Also, running `make build` will set the version to `dev` and set the current commit.

In addition, it uses the default build flags that goreleaser uses, so goreleaser should pick this up.