### PR TITLE
Move to a larger resource class to handle the multi-arch builds better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       - run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic
   snapshot:
     working_directory: /go/src/github.com/fairwindsops/rbac-lookup
+    resource_class: large
     docker:
       - image: goreleaser/goreleaser:v1.10.3
     steps:
@@ -55,6 +56,7 @@ jobs:
           path: dist
           destination: snapshot
   release:
+    resource_class: large
     working_directory: /go/src/github.com/fairwindsops/rbac-lookup
     docker:
       - image: goreleaser/goreleaser:v1.10.3


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
The tag builds are failing, this may fix it

### What changes did you make?
added resource_class: large to all goreleaser steps

### What alternative solution should we consider, if any?
n/a